### PR TITLE
Fix release job

### DIFF
--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -90,19 +90,19 @@ main {
 release {
   jobs {
     new {
-      ["deploy-release"] {
+      ["github-release"] {
         context {
-          "pkl-maven-release"
+          "pkl-github-release"
         }
       }
     }
     new {
-      ["github-release"] {
-        requires {
-          "deploy-release"
-        }
+      ["deploy-release"] {
         context {
-          "pkl-github-release"
+          "pkl-maven-release"
+        }
+        requires {
+          "github-release"
         }
       }
     }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,17 +76,7 @@ workflows:
       - << pipeline.git.branch >>
   release:
     jobs:
-    - deploy-release:
-        context:
-        - pkl-maven-release
-        filters:
-          branches:
-            ignore: /.*/
-          tags:
-            only: /^v?\d+\.\d+\.\d+$/
     - github-release:
-        requires:
-        - deploy-release
         context:
         - pkl-github-release
         filters:
@@ -94,9 +84,19 @@ workflows:
             ignore: /.*/
           tags:
             only: /^v?\d+\.\d+\.\d+$/
-    - trigger-docsite-build:
+    - deploy-release:
         requires:
         - github-release
+        context:
+        - pkl-maven-release
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v?\d+\.\d+\.\d+$/
+    - trigger-docsite-build:
+        requires:
+        - deploy-release
         context:
         - pkl-pr-approval
         filters:


### PR DESCRIPTION
When releasing, we should create a GitHub release first, because these are mutable (we can roll them back if something later goes wrong with the Maven release).

Also, it's possible that our CI job will time out before our sonatype repo closes, but this shouldn't prevent the github release from being published.