### PR TITLE
Clean up stale CI badge and redundant auto-config

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-= Pkl Spring Boot Integration image:https://circleci.com/gh/apple/pkl-spring.svg?style=svg["pkl-spring", link="https://circleci.com/gh/apple/pkl-spring"]
+= Pkl Spring Boot Integration
 :uri-docs: https://pkl-lang.org/spring/current
 :uri-installation: {uri-docs}/installation
 :uri-usage: {uri-docs}/usage

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,1 @@
 org.springframework.boot.env.PropertySourceLoader=org.pkl.spring.boot.PklPropertySourceLoader
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.pkl.spring.boot.PklAutoConfiguration


### PR DESCRIPTION
## Summary

Two small post-CI-migration cleanups:

- **`README.adoc`**: The CircleCI badge has been broken since CI was moved to GitHub Actions in #19 and the CircleCI config reference was removed in #20. Other `apple/pkl-*` repositories (`pkl`, `pkl-go`, `pkl-k8s`, `pkl-pantry`, `pkl-intellij`) do not display a CI status badge in their README, so this PR drops the badge rather than substituting a GitHub Actions one — keeping the family of repos consistent.

- **`META-INF/spring.factories`**: `PklAutoConfiguration` is already declared in `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` since #16. The matching `EnableAutoConfiguration=` entry in `spring.factories` is therefore redundant — Spring Boot 3 prefers the new imports file. The `PropertySourceLoader=` entry is kept untouched, because Spring Boot still loads `PropertySourceLoader` implementations exclusively from `spring.factories`.

## Test plan

- [x] `README.adoc` change is documentation-only; renders cleanly.
- [x] `spring.factories` still contains the `PropertySourceLoader` line — verified via `grep -rn 'PklAutoConfiguration\|PklPropertySourceLoader' src/`.
- [ ] CI to confirm `ConfigTest` still passes (no behavioural change expected — the new-style imports file already drives auto-configuration since #16).