### PR TITLE
Add Spring Boot Maven sample

### DIFF
--- a/samples/spring-boot-maven/README.adoc
+++ b/samples/spring-boot-maven/README.adoc
@@ -1,0 +1,25 @@
+= Spring Boot Example (Maven)
+:uri-docs: https://pkl-lang.org/spring/current/spring-boot.html
+
+This example demonstrates how to configure a Spring Boot application with Pkl using Maven.
+For a walkthrough of the underlying integration, see the link:{uri-docs}[documentation].
+
+The build invokes Pkl's Java code generator during the `generate-sources` phase via
+`exec-maven-plugin`, then registers the generated directory as an additional source root
+via `build-helper-maven-plugin`. The generated `AppConfig` class is annotated with
+`@ConfigurationProperties` and picked up by Spring Boot at startup.
+
+== Run
+
+[source,shell]
+----
+mvn spring-boot:run
+----
+
+To package the application as an executable jar:
+
+[source,shell]
+----
+mvn package
+java -jar target/spring-boot-maven-1.0.0-SNAPSHOT.jar
+----

--- a/samples/spring-boot-maven/pom.xml
+++ b/samples/spring-boot-maven/pom.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.5.6</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>org.pkl-lang.samples</groupId>
+  <artifactId>spring-boot-maven</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <properties>
+    <java.version>17</java.version>
+    <pkl.version>0.31.1</pkl.version>
+    <pkl-spring.version>0.18.0</pkl-spring.version>
+    <generated.root.directory>${project.build.directory}/generated-sources/pkl</generated.root.directory>
+    <generated.sources.directory>${generated.root.directory}/java</generated.sources.directory>
+    <generated.resources.directory>${generated.root.directory}/resources</generated.resources.directory>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.pkl-lang</groupId>
+      <artifactId>pkl-spring</artifactId>
+      <version>${pkl-spring.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <id>pkl-codegen</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <configuration>
+              <mainClass>org.pkl.codegen.java.Main</mainClass>
+              <arguments>
+                <argument>--output-dir</argument>
+                <argument>${generated.root.directory}</argument>
+                <argument>--generate-getters</argument>
+                <argument>--generate-spring-boot</argument>
+                <argument>${project.basedir}/src/main/resources/AppConfig.pkl</argument>
+              </arguments>
+              <includePluginDependencies>true</includePluginDependencies>
+              <includeProjectDependencies>false</includeProjectDependencies>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.pkl-lang</groupId>
+            <artifactId>pkl-tools</artifactId>
+            <version>${pkl.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.6.0</version>
+        <executions>
+          <execution>
+            <id>add-pkl-generated-sources</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${generated.sources.directory}</source>
+              </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-pkl-generated-resources</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>add-resource</goal>
+            </goals>
+            <configuration>
+              <resources>
+                <resource>
+                  <directory>${generated.resources.directory}</directory>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/samples/spring-boot-maven/src/main/java/samples/boot/maven/Application.java
+++ b/samples/spring-boot-maven/src/main/java/samples/boot/maven/Application.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package samples.boot.maven;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootApplication
+@ConfigurationPropertiesScan
+public class Application {
+  public static void main(String... args) {
+    new SpringApplication(Application.class).run(args);
+  }
+
+  @Bean
+  @SuppressWarnings("unused")
+  public CommandLineRunner commandLineRunner(ApplicationContext ctx) {
+    return args -> {
+      var server = ctx.getBean(Server.class);
+      System.out.println(server.getConfig());
+    };
+  }
+}

--- a/samples/spring-boot-maven/src/main/java/samples/boot/maven/Server.java
+++ b/samples/spring-boot-maven/src/main/java/samples/boot/maven/Server.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package samples.boot.maven;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class Server {
+  private final AppConfig.Server config;
+
+  public Server(AppConfig.Server config) {
+    this.config = config;
+  }
+
+  public AppConfig.Server getConfig() {
+    return config;
+  }
+}

--- a/samples/spring-boot-maven/src/main/resources/AppConfig.pkl
+++ b/samples/spring-boot-maven/src/main/resources/AppConfig.pkl
@@ -1,0 +1,14 @@
+// this module name determines the package and
+// class name of the generated Java config class
+module samples.boot.maven.AppConfig
+
+server: Server
+
+class Server {
+  endpoints: Listing<Endpoint>
+}
+
+class Endpoint {
+  name: String
+  port: UInt16
+}

--- a/samples/spring-boot-maven/src/main/resources/application.pkl
+++ b/samples/spring-boot-maven/src/main/resources/application.pkl
@@ -1,0 +1,14 @@
+amends "AppConfig.pkl"
+
+server {
+  endpoints {
+    new {
+      name = "endpoint1"
+      port = 1234
+    }
+    new {
+      name = "endpoint2"
+      port = 5678
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a third sample under `samples/spring-boot-maven/` that mirrors the existing Gradle `spring-boot` sample but builds with Maven. This addresses the requests in #2 for a Maven-based example.

### How the build is wired

- **`exec-maven-plugin`** runs `org.pkl.codegen.java.Main` (from `pkl-tools`) in the `generate-sources` phase, with `--generate-spring-boot --generate-getters`, writing the generated sources/resources under `target/generated-sources/pkl/`.
- **`build-helper-maven-plugin`** adds `target/generated-sources/pkl/java` as an extra source root, and the matching `resources/` directory as an extra resource root so the `org.pkl.config.java.mapper` `.properties` mapper file ends up on the classpath.
- **`spring-boot-maven-plugin`** enables `mvn spring-boot:run` and produces an executable jar via `mvn package`.

### Files

- `pom.xml` — Spring Boot starter parent 3.5.6, `pkl-spring` 0.18.0, `pkl-tools` 0.31.1, Java 17.
- `src/main/resources/AppConfig.pkl` + `application.pkl` — same shape as the Gradle sample (a `Server` with a `Listing<Endpoint>`).
- `src/main/java/samples/boot/maven/Application.java` + `Server.java` — same `@ConfigurationPropertiesScan` + `CommandLineRunner` pattern as the Gradle sample, namespaced under `samples.boot.maven` to avoid collision.
- `README.adoc` — `mvn spring-boot:run` + executable-jar instructions.

## Test plan

Verified locally with Apache Maven 3.6.3 and Oracle JDK 17.0.12:

- [x] `mvn package` succeeds, executable jar built.
- [x] `java -jar target/spring-boot-maven-1.0.0-SNAPSHOT.jar` starts Spring Boot 3.5.6, binds `application.pkl` to the generated `AppConfig`, and prints the configured `Server` bean with both endpoints (`endpoint1:1234`, `endpoint2:5678`).
- [x] `mvn spring-boot:run` produces the same output.
- [x] Generated `AppConfig.java` lands at `target/generated-sources/pkl/java/samples/boot/maven/AppConfig.java` and the mapper `.properties` lands at `target/generated-sources/pkl/resources/META-INF/org/pkl/config/java/mapper/classes/`.

Fixes #2 if accepted.